### PR TITLE
Allow intercept of transitive require calls files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,17 @@
 
 var Module = module.constructor;
 var path = require('path');
+var assert = require('assert');
 
 module.exports = requireFromString;
 module.exports.load = load;
 
 function requireFromString(code, filename, opts) {
+	if (typeof filename === 'object') {
+		opts = filename;
+		filename = undefined;
+	}
+
 	if (typeof code !== 'string') {
 		throw new Error('code must be a string, not ' + typeof code);
 	}
@@ -32,9 +38,14 @@ function load(filename, opts) {
 	var paths = Module._nodeModulePaths(path.dirname(filename));
 
 	var m = new Module(filename, module.parent);
-	if (opts.require) {
+
+	var requireHook = opts.require;
+
+	if (requireHook) {
 		m.require = function (path) {
-			return opts.require.call(this, path);
+			assert(typeof path === 'string', 'path must be a string');
+			assert(path, 'missing path');
+			return requireHook.call(this, path);
 		}
 	}
 	m.filename = filename;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,18 @@
 var Module = module.constructor;
 var path = require('path');
 
-module.exports = function requireFromString(code, filename, opts) {
+module.exports = requireFromString;
+module.exports.load = load;
+
+function requireFromString(code, filename, opts) {
+	var m = load(code, filename, opts);
+
+	m._compile(code, filename);
+
+	return m.exports;
+}
+
+function load(code, filename, opts) {
 	if (typeof filename === 'object') {
 		opts = filename;
 		filename = undefined;
@@ -28,7 +39,5 @@ module.exports = function requireFromString(code, filename, opts) {
 	}
 	m.filename = filename;
 	m.paths = [].concat(opts.prependPaths).concat(paths).concat(opts.appendPaths);
-	m._compile(code, filename);
-
-	return m.exports;
-};
+	return m;
+}

--- a/index.js
+++ b/index.js
@@ -7,14 +7,18 @@ module.exports = requireFromString;
 module.exports.load = load;
 
 function requireFromString(code, filename, opts) {
-	var m = load(code, filename, opts);
+	if (typeof code !== 'string') {
+		throw new Error('code must be a string, not ' + typeof code);
+	}
+
+	var m = load(filename, opts);
 
 	m._compile(code, filename);
 
 	return m.exports;
 }
 
-function load(code, filename, opts) {
+function load(filename, opts) {
 	if (typeof filename === 'object') {
 		opts = filename;
 		filename = undefined;
@@ -24,10 +28,6 @@ function load(code, filename, opts) {
 
 	opts.appendPaths = opts.appendPaths || [];
 	opts.prependPaths = opts.prependPaths || [];
-
-	if (typeof code !== 'string') {
-		throw new Error('code must be a string, not ' + typeof code);
-	}
 
 	var paths = Module._nodeModulePaths(path.dirname(filename));
 

--- a/index.js
+++ b/index.js
@@ -21,6 +21,11 @@ module.exports = function requireFromString(code, filename, opts) {
 	var paths = Module._nodeModulePaths(path.dirname(filename));
 
 	var m = new Module(filename, module.parent);
+	if (opts.require) {
+		m.require = function (path) {
+			return opts.require.call(this, path);
+		}
+	}
 	m.filename = filename;
 	m.paths = [].concat(opts.prependPaths).concat(paths).concat(opts.appendPaths);
 	m._compile(code, filename);

--- a/test/fixture/depth0.js
+++ b/test/fixture/depth0.js
@@ -1,0 +1,2 @@
+
+module.exports = require('./depth1');

--- a/test/fixture/depth1/depth2/index.js
+++ b/test/fixture/depth1/depth2/index.js
@@ -1,0 +1,1 @@
+module.exports = 'FOO - depth2';

--- a/test/fixture/depth1/index.js
+++ b/test/fixture/depth1/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./depth2');

--- a/test/fixture/greet-james.js
+++ b/test/fixture/greet-james.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+	return 'Hello ' + require('./james');
+};

--- a/test/fixture/james.js
+++ b/test/fixture/james.js
@@ -1,0 +1,1 @@
+module.exports = 'James';

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,13 @@ var fs = require('fs');
 var path = require('path');
 var requireFromString = require('../');
 
+function getFixture(file) {
+	file = path.join(__dirname, 'fixture', file);
+	var code = fs.readFileSync(file, 'utf8');
+
+	return {file: file, code: code};
+}
+
 it('should accept only string as code', function () {
 	assert.throws(function () {
 		requireFromString();
@@ -24,18 +31,16 @@ it('should accept filename', function () {
 });
 
 it('should work with relative require in file', function () {
-	var file = path.join(__dirname, '/fixture/module.js');
-	var code = fs.readFileSync(file, 'utf8');
-	var result = requireFromString(code, file);
+	var fixture = getFixture('module.js');
+	var result = requireFromString(fixture.code, fixture.file);
 
 	assert.ok(result);
 	assert.ok(module === result.parent.parent);
 });
 
 it('should have appended and preppended paths', function () {
-	var file = path.join(__dirname, '/fixture/submodule.js');
-	var code = fs.readFileSync(file, 'utf8');
-	var result = requireFromString(code, file, {
+	var fixture = getFixture('submodule.js');
+	var result = requireFromString(fixture.code, fixture.file, {
 		appendPaths: ['append'],
 		prependPaths: ['prepend']
 	});
@@ -43,4 +48,42 @@ it('should have appended and preppended paths', function () {
 	assert.ok(result);
 	assert.equal(result.paths.indexOf('append'), result.paths.length - 1);
 	assert.equal(result.paths.indexOf('prepend'), 0);
+});
+
+it('should allow modification of other required modules via callback', function () {
+	var fixture = getFixture('greet-james.js');
+	var Module = module.constructor;
+
+	function transform(code) {
+		return code.replace('James', 'Jim');
+	}
+
+	function requireHook(path) {
+		var file = Module._resolveFilename(path, this);
+		var code = fs.readFileSync(file, 'utf8');
+		return requireFromString(transform(code), file, {require: requireHook});
+	}
+
+	var result = requireFromString(fixture.code, fixture.file, {require: requireHook});
+
+	assert.equal(result(), 'Hello Jim');
+});
+
+it('transforms should be doable even as relative directory changes', function () {
+	var fixture = getFixture('depth0.js');
+	var Module = module.constructor;
+
+	function transform(code) {
+		return code.replace('FOO', 'BAR');
+	}
+
+	function requireHook(path) {
+		var file = Module._resolveFilename(path, this);
+		var code = fs.readFileSync(file, 'utf8');
+		return requireFromString(transform(code), file, {require: requireHook});
+	}
+
+	var result = requireFromString(fixture.code, fixture.file, {require: requireHook});
+
+	assert.equal(result, 'BAR - depth2');
 });


### PR DESCRIPTION
This paves the way for https://github.com/sindresorhus/ava/issues/156

This provides a really barebones API for intercepting require calls inside the module. It is up to the implementor to provide caching, resolve file names, load from disk, etc. (which we want to handle ourselves inside `ava` anyways).

// @sindresorhus @vdemedes
