### PR TITLE
Node v6 support. Default filename to empty string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function requireFromString(code, filename, opts) {
 	}
 
 	opts = opts || {};
+	filename = filename || '';
 
 	opts.appendPaths = opts.appendPaths || [];
 	opts.prependPaths = opts.prependPaths || [];


### PR DESCRIPTION
Node v6 throws if the input to a `path` function is not a string. See [here](https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#path).
