### PR TITLE
Require 'module' instead of referencing constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Module = module.constructor;
+var Module = require('module');
 var path = require('path');
 
 module.exports = function requireFromString(code, filename, opts) {


### PR DESCRIPTION
Referencing `module.constructor` was causing a problem when trying to run in the [Jest](https://github.com/facebook/jest) testing framework.

This is because Jest re-implements Nodes module system so `module.constructor` wasn't referencing the builtin node 'module' meaning it would throw on `Module._nodeModulePaths(...)`.