### PR TITLE
Cleanup module.children after evaluating

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,10 +21,14 @@ module.exports = function requireFromString(code, filename, opts) {
 
 	var paths = Module._nodeModulePaths(path.dirname(filename));
 
-	var m = new Module(filename, module.parent);
+	var parent = module.parent;
+	var m = new Module(filename, parent);
 	m.filename = filename;
 	m.paths = [].concat(opts.prependPaths).concat(paths).concat(opts.appendPaths);
 	m._compile(code, filename);
 
-	return m.exports;
+	var exports = m.exports;
+	parent.children.splice(parent.children.indexOf(m), 1);
+
+	return exports;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -58,3 +58,11 @@ it('should have meaningful error message', function () {
 		assert.ok(/\(<anonymous>:1:69\)/.test(err.stack), 'should contain (<anonymous>:1:69) in stack');
 	}
 });
+
+it('should cleanup parent.children', function() {
+	var file = path.join(__dirname, '/fixture/submodule.js');
+	var code = fs.readFileSync(file, 'utf8');
+	var result = requireFromString(code, file);
+
+	assert.ok(module.children.indexOf(result) === -1);
+});


### PR DESCRIPTION
I've stumbled upon this while trying to debug a memory leak in [`postcss-loader`](https://github.com/postcss/postcss-loader). It uses [`cosmiconfig`](https://github.com/davidtheclark/cosmiconfig) which in turn uses `require-from-string` to load javascript config. The problem is, `Module` constructor adds newly created module to `parent.children` which prevents evaluated values from ever getting garbage collected.