### PR TITLE
Check parent.children before splice, accommodate jest

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function requireFromString(code, filename, opts) {
 	m._compile(code, filename);
 
 	var exports = m.exports;
-	parent.children.splice(parent.children.indexOf(m), 1);
+	parent.children && parent.children.splice(parent.children.indexOf(m), 1);
 
 	return exports;
 };


### PR DESCRIPTION
When used with jest, `parent.children` will be `undefined`.

`console.log(module)`:

```
{ exports: [Function: requireFromString],
      filename: 'E:/Projects/repos/cosmiconfig/node_modules/require-from-string/index.js',
      id: 'E:/Projects/repos/cosmiconfig/node_modules/require-from-string/index.js',
      children: [],
      parent: { exports: {}, filename: 'mock.js', id: 'mockParent' },
      paths:
       [ 'E:/Projects/repos/cosmiconfig/node_modules/require-from-string/node_modules',
         'E:/Projects/repos/cosmiconfig/node_modules/node_modules',
         'E:/Projects/repos/cosmiconfig/node_modules',
         'E:/Projects/repos/node_modules',
         'E:/Projects/node_modules',
         'E:/node_modules' ],
      require:
       { [Function: bound requireModuleOrMock]
         cache: {},
         extensions: {},
         requireActual: [Function: bound requireModule],
         requireMock: [Function: bound requireMock],
         resolve: [Function] } }
```

This causes the following error:
```
TypeError: Cannot read property 'splice' of undefined                   
                                                                        
  at requireFromString (node_modules/require-from-string/index.js:31:17)
  at parseContent (src/loadDefinedFile.js:32:24)                        
  at loadDefinedFile (src/loadDefinedFile.js:50:3)                      
  at load (src/createExplorer.js:83:9)                                  
  at load (src/createExplorer.js:89:26)                                 
  at configFileLoader (test/util.js:12:10)                              
  at Object.<anonymous> (test/successful-files.test.js:14:34)           
      at Promise (<anonymous>)                                          
```

This adds a short-circuit check before attempting to splice it.